### PR TITLE
update GitAuto 

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,5 @@
 # # Your gitlab id
-# USER = 
+# USER_NAME = 
 
 # # Root directory you want
-# ROOT_PATH = 
+# ROOT_PATH =

--- a/func.py
+++ b/func.py
@@ -4,8 +4,6 @@ import subprocess
 from dotenv import load_dotenv
 
 load_dotenv()
-USER_ID = os.environ.get('USER_ID')
-
 
 def progressBar(count_value, total, suffix=''):
     bar_length = 100
@@ -16,7 +14,8 @@ def progressBar(count_value, total, suffix=''):
     sys.stdout.flush()
 
 
-def clone_git(USER_ID):
+def clone_git(user):
+    print(f"gitlab ID: {user}")
     subject = input("Subject: ")
     if not os.path.exists(subject):
         os.makedirs(subject)
@@ -42,12 +41,12 @@ def clone_git(USER_ID):
                 subprocess.run(['git', 'pull', 'origin', 'master'])
                 os.chdir('..')
             else:
-                url = f"https://lab.ssafy.com/{USER_ID}/{subject}_{sep}_{set_num}_{st}"
+                url = f"https://lab.ssafy.com/{user}/{subject}_{sep}_{set_num}_{st}"
                 print(f"git clone {url}")
                 subprocess.run(['git', 'clone', url])
 
 
-def push_git(USER_ID):
+def push_git():  # USER_ID 사용되지 않음 
     print("Select one")
     push_task = input("[1.push] / 2.commit / 3.add / 4.only backup: ")
     push_task = 1 if not push_task else int(push_task)

--- a/git_auto.py
+++ b/git_auto.py
@@ -2,14 +2,14 @@ import os
 from func import *
 from dotenv import load_dotenv, find_dotenv
 
-dotenv_file = find_dotenv()
-load_dotenv(dotenv_file)
-USER = os.environ['USER']
+
+load_dotenv()
+USER = os.environ['USER_NAME']
 ROOT = os.environ['ROOT_PATH']
 
 
 if __name__ == '__main__':
-    # print(USER, ROOT)
+
     os.chdir(ROOT)
 
     task = input("clone / push: ")

--- a/git_auto.py
+++ b/git_auto.py
@@ -18,4 +18,4 @@ if __name__ == '__main__':
         clone_git(USER)
 
     elif task == 'push':
-        push_git(USER)
+        push_git()


### PR DESCRIPTION
mac 환경에서 사용 시, 운영체제 자체 시스템 환경 변수 USER에 의해 .env 파일의 USER 변수가 가려지는 버그를 수정했습니다. 
Windows 환경에서 테스트 후 Merge 부탁드립니다. 
첨부한 이미지는 기존 코드 실행 시 `USER='woghks1213'`지정 했음에도 gitlab ID로 jaehwan(시스템 자체 USER)가 출력되는 상황입니다.
<img width="763" alt="스크린샷 2024-08-01 21 00 33" src="https://github.com/user-attachments/assets/fa53a273-2ba9-439d-9b67-a98b753fe931">
### 1. .env.template  
- USER -> USER_NAME 
### 2. func.py 
- 운영체제 자체 USER_ID 가져오는 부분 삭제 
- gitlab ID 확인 코드 추가 
- clone_git() 매개변수 이름 변경 : USER_ID -> user
- push_git() 매개변수 삭제 (사용되지 않음)
### 3. git_auto.py 
- USER -> USER_NAME 

